### PR TITLE
Add blocklist checking, exit IP, CONNECT detection, and TLS validation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ This is a Go monorepo that produces three container images for an open proxy sca
 Three components, three container images:
 
 1. **Scanner** (`docker/Dockerfile.scanner`) — Alpine + masscan. Runs as a K8s CronJob. Scans IPv4 space for open proxy ports. Outputs JSON to a shared PVC.
-2. **Validator** (`cmd/validator/`, `docker/Dockerfile.validator`) — Go binary. Runs as a K8s Job after the scanner. Reads masscan output, validates each candidate as a working proxy (HTTP/HTTPS/SOCKS4/SOCKS5), measures latency, checks anonymity, tags with GeoIP. Writes to SQLite on the shared PVC.
+2. **Validator** (`cmd/validator/`, `docker/Dockerfile.validator`) — Go binary. Runs as a K8s Job after the scanner. Reads masscan output, validates each candidate as a working proxy (HTTP/HTTPS/SOCKS4/SOCKS5), measures latency, checks anonymity, checks DNSBL blocklists, detects CONNECT support and TLS cert issues, tags with GeoIP. Writes to SQLite on the shared PVC.
 3. **API** (`cmd/api/`, `docker/Dockerfile.api`) — Go REST API. Runs as a K8s Deployment. Serves proxy data from SQLite. Internal ClusterIP service for other cluster workloads.
 
 ## Code Structure
@@ -18,6 +18,7 @@ Three components, three container images:
 cmd/validator/main.go    — Validator entry point (worker pool, egress IP detection)
 cmd/api/main.go          — API entry point (REST endpoints, request logging)
 internal/proxy/          — Proxy checking logic (checker.go, geoip.go, types.go)
+internal/blocklist/      — DNSBL blocklist checking (dnsbl.go)
 internal/database/       — SQLite operations (sqlite.go)
 internal/scanner/        — Masscan output parser (parser.go)
 data/                    — GeoLite2 .mmdb databases (City, ASN, Country) — committed to repo
@@ -57,6 +58,7 @@ deploy/                  — Example Kubernetes manifests (reference only)
 - `WORKERS` — Number of concurrent validation goroutines (default: `500`)
 - `TIMEOUT` — Per-proxy validation timeout in seconds (default: `10`)
 - `TEST_URL` — URL to request through the proxy for validation (default: `http://httpbin.org/ip`)
+- `SKIP_BLOCKLIST` — Set to `true` to disable DNSBL blocklist checking (default: `false`)
 
 ### API (`cmd/api`)
 - `DB_PATH` — Path to SQLite database (default: `/data/proxies.db`)
@@ -70,7 +72,8 @@ deploy/                  — Example Kubernetes manifests (reference only)
 - No global state. Pass dependencies explicitly.
 - Database operations go through the `database.DB` struct, not raw SQL in business logic.
 - Proxy checking logic is in `internal/proxy/checker.go`. Each protocol has its own check function.
-- The validator orchestrates: parse input -> fan out to workers -> collect results -> write to DB.
+- Blocklist checking is in `internal/blocklist/dnsbl.go`. Uses DNSBL (DNS-based blocklists) to flag known-abuse IPs.
+- The validator orchestrates: parse input -> fan out to workers -> check proxy -> check blocklists -> write to DB.
 
 ## Testing
 

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -203,6 +203,12 @@ func parseFilter(r *http.Request) proxy.ProxyFilter {
 	if v := q.Get("alive"); v == "false" || v == "0" {
 		f.AliveOnly = false
 	}
+	if v := q.Get("blocklisted"); v != "" {
+		b, err := strconv.ParseBool(v)
+		if err == nil {
+			f.Blocklisted = &b
+		}
+	}
 
 	return f
 }

--- a/cmd/validator/main.go
+++ b/cmd/validator/main.go
@@ -15,6 +15,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/venatiodecorus/proxy-scanner/internal/blocklist"
 	"github.com/venatiodecorus/proxy-scanner/internal/database"
 	"github.com/venatiodecorus/proxy-scanner/internal/proxy"
 	"github.com/venatiodecorus/proxy-scanner/internal/scanner"
@@ -42,6 +43,7 @@ func run(logger *slog.Logger) error {
 	timeout := envOrDefaultInt("TIMEOUT", 10)
 	testURL := envOrDefault("TEST_URL", "http://httpbin.org/ip")
 	originIP := envOrDefault("ORIGIN_IP", "")
+	skipBlocklist := envOrDefaultBool("SKIP_BLOCKLIST", false)
 
 	// Auto-detect egress IP if not explicitly set
 	if originIP == "" {
@@ -64,6 +66,7 @@ func run(logger *slog.Logger) error {
 		"timeout", timeout,
 		"test_url", testURL,
 		"origin_ip", originIP,
+		"skip_blocklist", skipBlocklist,
 	)
 
 	// Setup context with graceful shutdown
@@ -118,6 +121,15 @@ func run(logger *slog.Logger) error {
 		Logger:   logger,
 	}
 	checker := proxy.NewChecker(checkerCfg)
+
+	// Initialize blocklist checker
+	var blChecker *blocklist.Checker
+	if !skipBlocklist {
+		blChecker = blocklist.NewChecker(blocklist.WithLogger(logger))
+		logger.Info("blocklist checking enabled")
+	} else {
+		logger.Info("blocklist checking disabled")
+	}
 
 	// Stream-parse masscan output. This uses a streaming JSON decoder so we
 	// never hold the entire file in memory — critical for large scan outputs
@@ -175,20 +187,36 @@ func run(logger *slog.Logger) error {
 						continue
 					}
 
-					// GeoIP lookup
 					geo := geoip.Lookup(result.Candidate.IP)
 
 					p := &proxy.Proxy{
-						IP:        result.Candidate.IP,
-						Port:      result.Candidate.Port,
-						Protocol:  result.Protocol,
-						Anonymity: result.Anonymity,
-						Country:   geo.Country,
-						City:      geo.City,
-						ASN:       geo.ASN,
-						ASNOrg:    geo.ASNOrg,
-						LatencyMs: result.LatencyMs,
-						Alive:     true,
+						IP:              result.Candidate.IP,
+						Port:            result.Candidate.Port,
+						Protocol:        result.Protocol,
+						Anonymity:       result.Anonymity,
+						Country:         geo.Country,
+						City:            geo.City,
+						ASN:             geo.ASN,
+						ASNOrg:          geo.ASNOrg,
+						ExitIP:          result.ExitIP,
+						LatencyMs:       result.LatencyMs,
+						SupportsConnect: result.SupportsConnect,
+						TLSInsecure:     result.TLSInsecure,
+						Alive:           true,
+					}
+
+					// Blocklist check
+					if blChecker != nil {
+						blResult := blChecker.Check(ctx, p.IP)
+						p.Blocklisted = blResult.Listed
+						p.Blocklists = blResult.BlocklistsString()
+						if p.Blocklisted {
+							logger.Debug("proxy on blocklist",
+								"ip", p.IP,
+								"port", p.Port,
+								"blocklists", p.Blocklists,
+							)
+						}
 					}
 
 					if err := db.UpsertProxy(p); err != nil {
@@ -314,4 +342,16 @@ func envOrDefaultInt(key string, def int) int {
 		return def
 	}
 	return n
+}
+
+func envOrDefaultBool(key string, def bool) bool {
+	v := os.Getenv(key)
+	if v == "" {
+		return def
+	}
+	b, err := strconv.ParseBool(v)
+	if err != nil {
+		return def
+	}
+	return b
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,7 @@ services:
       WORKERS: "500"
       TIMEOUT: "10"
       TEST_URL: "http://httpbin.org/ip"
+      # SKIP_BLOCKLIST: "true"  # uncomment to disable DNSBL checking
 
 volumes:
   scanner-data:

--- a/internal/blocklist/dnsbl.go
+++ b/internal/blocklist/dnsbl.go
@@ -1,0 +1,146 @@
+package blocklist
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net"
+	"strings"
+	"sync"
+)
+
+var defaultLists = []string{
+	"zen.spamhaus.org",
+	"dnsbl-1.uceprotect.net",
+	"dnsbl.sorbs.net",
+	"dnsbl.dronebl.org",
+}
+
+type Resolver interface {
+	LookupHost(ctx context.Context, host string) ([]string, error)
+}
+
+type Result struct {
+	Listed     bool
+	Blocklists []string
+}
+
+type Checker struct {
+	lists    []string
+	logger   *slog.Logger
+	resolver Resolver
+}
+
+type Option func(*Checker)
+
+func WithLists(lists []string) Option {
+	return func(c *Checker) {
+		c.lists = lists
+	}
+}
+
+func WithLogger(logger *slog.Logger) Option {
+	return func(c *Checker) {
+		c.logger = logger
+	}
+}
+
+func WithResolver(r Resolver) Option {
+	return func(c *Checker) {
+		c.resolver = r
+	}
+}
+
+func NewChecker(opts ...Option) *Checker {
+	c := &Checker{
+		lists:    defaultLists,
+		logger:   slog.Default(),
+		resolver: net.DefaultResolver,
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
+}
+
+func (c *Checker) Check(ctx context.Context, ip string) Result {
+	reversed := reverseIP(ip)
+	var wg sync.WaitGroup
+	type listResult struct {
+		list  string
+		found bool
+	}
+	results := make(chan listResult, len(c.lists))
+
+	for _, list := range c.lists {
+		wg.Add(1)
+		go func(list string) {
+			defer wg.Done()
+			query := fmt.Sprintf("%s.%s", reversed, list)
+			addrs, err := c.resolver.LookupHost(ctx, query)
+			if err != nil || len(addrs) == 0 {
+				results <- listResult{list: list, found: false}
+				return
+			}
+			c.logger.Debug("blocklist hit", "ip", ip, "list", list, "addrs", addrs)
+			results <- listResult{list: list, found: true}
+		}(list)
+	}
+
+	go func() {
+		wg.Wait()
+		close(results)
+	}()
+
+	var hitLists []string
+	for r := range results {
+		if r.found {
+			hitLists = append(hitLists, r.list)
+		}
+	}
+
+	return Result{
+		Listed:     len(hitLists) > 0,
+		Blocklists: hitLists,
+	}
+}
+
+func (c *Checker) CheckBatch(ctx context.Context, ips []string) map[string]Result {
+	results := make(map[string]Result, len(ips))
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+
+	for _, ip := range ips {
+		wg.Add(1)
+		go func(ip string) {
+			defer wg.Done()
+			r := c.Check(ctx, ip)
+			mu.Lock()
+			results[ip] = r
+			mu.Unlock()
+		}(ip)
+	}
+	wg.Wait()
+
+	return results
+}
+
+func (r Result) BlocklistsString() string {
+	if len(r.Blocklists) == 0 {
+		return ""
+	}
+	shortNames := make([]string, len(r.Blocklists))
+	for i, bl := range r.Blocklists {
+		parts := strings.SplitN(bl, ".", 2)
+		shortNames[i] = parts[0]
+	}
+	return strings.Join(shortNames, ",")
+}
+
+func reverseIP(ip string) string {
+	parts := strings.Split(ip, ".")
+	if len(parts) != 4 {
+		return ip
+	}
+	return fmt.Sprintf("%s.%s.%s.%s", parts[3], parts[2], parts[1], parts[0])
+}

--- a/internal/blocklist/dnsbl_test.go
+++ b/internal/blocklist/dnsbl_test.go
@@ -1,0 +1,139 @@
+package blocklist
+
+import (
+	"context"
+	"net"
+	"sync"
+	"testing"
+)
+
+type mockResolver struct {
+	results map[string][]string
+	err     map[string]error
+	mu      sync.Mutex
+}
+
+func (m *mockResolver) LookupHost(ctx context.Context, host string) ([]string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if err, ok := m.err[host]; ok {
+		return nil, err
+	}
+	if addrs, ok := m.results[host]; ok {
+		return addrs, nil
+	}
+	return nil, &net.DNSError{Err: "not found", Name: host}
+}
+
+func TestReverseIP(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"192.168.1.1", "1.1.168.192"},
+		{"10.0.0.1", "1.0.0.10"},
+		{"1.2.3.4", "4.3.2.1"},
+	}
+	for _, tt := range tests {
+		got := reverseIP(tt.input)
+		if got != tt.expected {
+			t.Errorf("reverseIP(%s) = %s, want %s", tt.input, got, tt.expected)
+		}
+	}
+}
+
+func TestChecker_Check_NotListed(t *testing.T) {
+	mock := &mockResolver{}
+	c := NewChecker(
+		WithLists([]string{"test.bl.example.com"}),
+		WithResolver(mock),
+	)
+
+	result := c.Check(context.Background(), "192.168.1.1")
+	if result.Listed {
+		t.Error("expected not listed, got listed")
+	}
+	if len(result.Blocklists) != 0 {
+		t.Errorf("expected no blocklists, got %v", result.Blocklists)
+	}
+}
+
+func TestChecker_Check_Listed(t *testing.T) {
+	mock := &mockResolver{
+		results: map[string][]string{
+			"1.1.168.192.test.bl.example.com": {"127.0.0.2"},
+		},
+	}
+	c := NewChecker(
+		WithLists([]string{"test.bl.example.com"}),
+		WithResolver(mock),
+	)
+
+	result := c.Check(context.Background(), "192.168.1.1")
+	if !result.Listed {
+		t.Error("expected listed, got not listed")
+	}
+	if len(result.Blocklists) != 1 || result.Blocklists[0] != "test.bl.example.com" {
+		t.Errorf("expected blocklist [test.bl.example.com], got %v", result.Blocklists)
+	}
+}
+
+func TestChecker_Check_MultipleLists(t *testing.T) {
+	mock := &mockResolver{
+		results: map[string][]string{
+			"1.0.0.10.list1.example.com": {"127.0.0.2"},
+			"1.0.0.10.list2.example.com": {"127.0.0.4"},
+		},
+	}
+	c := NewChecker(
+		WithLists([]string{"list1.example.com", "list2.example.com", "list3.example.com"}),
+		WithResolver(mock),
+	)
+
+	result := c.Check(context.Background(), "10.0.0.1")
+	if !result.Listed {
+		t.Error("expected listed")
+	}
+	if len(result.Blocklists) != 2 {
+		t.Errorf("expected 2 blocklists, got %d", len(result.Blocklists))
+	}
+}
+
+func TestResult_BlocklistsString(t *testing.T) {
+	r := Result{
+		Listed:     true,
+		Blocklists: []string{"zen.spamhaus.org", "dnsbl.sorbs.net"},
+	}
+	s := r.BlocklistsString()
+	if s != "zen,dnsbl" {
+		t.Errorf("expected 'zen,dnsbl', got '%s'", s)
+	}
+
+	r2 := Result{Listed: false, Blocklists: nil}
+	if r2.BlocklistsString() != "" {
+		t.Errorf("expected empty string, got '%s'", r2.BlocklistsString())
+	}
+}
+
+func TestChecker_CheckBatch(t *testing.T) {
+	mock := &mockResolver{
+		results: map[string][]string{
+			"1.0.0.10.list.example.com": {"127.0.0.2"},
+		},
+	}
+	c := NewChecker(
+		WithLists([]string{"list.example.com"}),
+		WithResolver(mock),
+	)
+
+	results := c.CheckBatch(context.Background(), []string{"10.0.0.1", "192.168.1.1"})
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+	if !results["10.0.0.1"].Listed {
+		t.Error("expected 10.0.0.1 to be listed")
+	}
+	if results["192.168.1.1"].Listed {
+		t.Error("expected 192.168.1.1 to not be listed")
+	}
+}

--- a/internal/database/sqlite.go
+++ b/internal/database/sqlite.go
@@ -51,19 +51,24 @@ func (d *DB) Close() error {
 func (d *DB) migrate() error {
 	schema := `
 	CREATE TABLE IF NOT EXISTS proxies (
-		id          INTEGER PRIMARY KEY AUTOINCREMENT,
-		ip          TEXT NOT NULL,
-		port        INTEGER NOT NULL,
-		protocol    TEXT NOT NULL,
-		anonymity   TEXT,
-		country     TEXT,
-		city        TEXT,
-		asn         INTEGER,
-		asn_org     TEXT,
-		latency_ms  INTEGER,
-		last_seen   DATETIME NOT NULL,
-		first_seen  DATETIME NOT NULL,
-		alive       BOOLEAN DEFAULT TRUE,
+		id               INTEGER PRIMARY KEY AUTOINCREMENT,
+		ip               TEXT NOT NULL,
+		port             INTEGER NOT NULL,
+		protocol         TEXT NOT NULL,
+		anonymity        TEXT,
+		country          TEXT,
+		city             TEXT,
+		asn              INTEGER,
+		asn_org          TEXT,
+		exit_ip          TEXT,
+		latency_ms       INTEGER,
+		supports_connect BOOLEAN DEFAULT FALSE,
+		tls_insecure     BOOLEAN DEFAULT FALSE,
+		blocklisted      BOOLEAN DEFAULT FALSE,
+		blocklists       TEXT,
+		last_seen        DATETIME NOT NULL,
+		first_seen       DATETIME NOT NULL,
+		alive            BOOLEAN DEFAULT TRUE,
 		UNIQUE(ip, port, protocol)
 	);
 
@@ -79,9 +84,54 @@ func (d *DB) migrate() error {
 	CREATE INDEX IF NOT EXISTS idx_proxies_alive ON proxies(alive, protocol);
 	CREATE INDEX IF NOT EXISTS idx_proxies_latency ON proxies(alive, latency_ms);
 	CREATE INDEX IF NOT EXISTS idx_proxies_country ON proxies(alive, country);
+	CREATE INDEX IF NOT EXISTS idx_proxies_blocklisted ON proxies(alive, blocklisted);
 	`
 	_, err := d.db.Exec(schema)
-	return err
+	if err != nil {
+		return err
+	}
+
+	var exitIPExists int
+	d.db.QueryRow("SELECT COUNT(*) FROM pragma_table_info('proxies') WHERE name = 'exit_ip'").Scan(&exitIPExists)
+	if exitIPExists == 0 {
+		if _, err := d.db.Exec("ALTER TABLE proxies ADD COLUMN exit_ip TEXT"); err != nil {
+			return fmt.Errorf("migrating exit_ip column: %w", err)
+		}
+	}
+
+	var supportsConnectExists int
+	d.db.QueryRow("SELECT COUNT(*) FROM pragma_table_info('proxies') WHERE name = 'supports_connect'").Scan(&supportsConnectExists)
+	if supportsConnectExists == 0 {
+		if _, err := d.db.Exec("ALTER TABLE proxies ADD COLUMN supports_connect BOOLEAN DEFAULT FALSE"); err != nil {
+			return fmt.Errorf("migrating supports_connect column: %w", err)
+		}
+	}
+
+	var tlsInsecureExists int
+	d.db.QueryRow("SELECT COUNT(*) FROM pragma_table_info('proxies') WHERE name = 'tls_insecure'").Scan(&tlsInsecureExists)
+	if tlsInsecureExists == 0 {
+		if _, err := d.db.Exec("ALTER TABLE proxies ADD COLUMN tls_insecure BOOLEAN DEFAULT FALSE"); err != nil {
+			return fmt.Errorf("migrating tls_insecure column: %w", err)
+		}
+	}
+
+	var blocklistedExists int
+	d.db.QueryRow("SELECT COUNT(*) FROM pragma_table_info('proxies') WHERE name = 'blocklisted'").Scan(&blocklistedExists)
+	if blocklistedExists == 0 {
+		if _, err := d.db.Exec("ALTER TABLE proxies ADD COLUMN blocklisted BOOLEAN DEFAULT FALSE"); err != nil {
+			return fmt.Errorf("migrating blocklisted column: %w", err)
+		}
+	}
+
+	var blocklistsExists int
+	d.db.QueryRow("SELECT COUNT(*) FROM pragma_table_info('proxies') WHERE name = 'blocklists'").Scan(&blocklistsExists)
+	if blocklistsExists == 0 {
+		if _, err := d.db.Exec("ALTER TABLE proxies ADD COLUMN blocklists TEXT"); err != nil {
+			return fmt.Errorf("migrating blocklists column: %w", err)
+		}
+	}
+
+	return nil
 }
 
 // UpsertProxy inserts or updates a proxy record. If the proxy already exists
@@ -89,19 +139,26 @@ func (d *DB) migrate() error {
 func (d *DB) UpsertProxy(p *proxy.Proxy) error {
 	now := time.Now().UTC()
 	_, err := d.db.Exec(`
-		INSERT INTO proxies (ip, port, protocol, anonymity, country, city, asn, asn_org, latency_ms, last_seen, first_seen, alive)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		INSERT INTO proxies (ip, port, protocol, anonymity, country, city, asn, asn_org, exit_ip, latency_ms, supports_connect, tls_insecure, blocklisted, blocklists, last_seen, first_seen, alive)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(ip, port, protocol) DO UPDATE SET
 			anonymity = excluded.anonymity,
 			country = excluded.country,
 			city = excluded.city,
 			asn = excluded.asn,
 			asn_org = excluded.asn_org,
+			exit_ip = excluded.exit_ip,
 			latency_ms = excluded.latency_ms,
+			supports_connect = excluded.supports_connect,
+			tls_insecure = excluded.tls_insecure,
+			blocklisted = excluded.blocklisted,
+			blocklists = excluded.blocklists,
 			last_seen = excluded.last_seen,
 			alive = excluded.alive
 	`, p.IP, p.Port, string(p.Protocol), string(p.Anonymity),
-		p.Country, p.City, p.ASN, p.ASNOrg, p.LatencyMs, now, now, p.Alive)
+		p.Country, p.City, p.ASN, p.ASNOrg, p.ExitIP, p.LatencyMs,
+		p.SupportsConnect, p.TLSInsecure, p.Blocklisted, p.Blocklists,
+		now, now, p.Alive)
 	if err != nil {
 		return fmt.Errorf("upserting proxy %s:%d: %w", p.IP, p.Port, err)
 	}
@@ -118,7 +175,7 @@ func (d *DB) MarkAllDead() error {
 // GetProxy returns a single proxy by ID.
 func (d *DB) GetProxy(id int64) (*proxy.Proxy, error) {
 	row := d.db.QueryRow(`
-		SELECT id, ip, port, protocol, anonymity, country, city, asn, asn_org, latency_ms, last_seen, first_seen, alive
+		SELECT id, ip, port, protocol, anonymity, country, city, asn, asn_org, exit_ip, latency_ms, supports_connect, tls_insecure, blocklisted, blocklists, last_seen, first_seen, alive
 		FROM proxies WHERE id = ?
 	`, id)
 	return scanProxy(row)
@@ -126,7 +183,7 @@ func (d *DB) GetProxy(id int64) (*proxy.Proxy, error) {
 
 // ListProxies returns proxies matching the given filter.
 func (d *DB) ListProxies(f proxy.ProxyFilter) ([]proxy.Proxy, error) {
-	query := "SELECT id, ip, port, protocol, anonymity, country, city, asn, asn_org, latency_ms, last_seen, first_seen, alive FROM proxies"
+	query := "SELECT id, ip, port, protocol, anonymity, country, city, asn, asn_org, exit_ip, latency_ms, supports_connect, tls_insecure, blocklisted, blocklists, last_seen, first_seen, alive FROM proxies"
 	where, args := buildWhere(f)
 	if where != "" {
 		query += " WHERE " + where
@@ -174,7 +231,7 @@ func (d *DB) RandomProxy(f proxy.ProxyFilter) (*proxy.Proxy, error) {
 	}
 
 	offset := rand.Intn(count)
-	query := "SELECT id, ip, port, protocol, anonymity, country, city, asn, asn_org, latency_ms, last_seen, first_seen, alive FROM proxies"
+	query := "SELECT id, ip, port, protocol, anonymity, country, city, asn, asn_org, exit_ip, latency_ms, supports_connect, tls_insecure, blocklisted, blocklists, last_seen, first_seen, alive FROM proxies"
 	if where != "" {
 		query += " WHERE " + where
 	}
@@ -319,6 +376,10 @@ func buildWhere(f proxy.ProxyFilter) (string, []interface{}) {
 		conditions = append(conditions, "latency_ms <= ?")
 		args = append(args, f.MaxLatency)
 	}
+	if f.Blocklisted != nil {
+		conditions = append(conditions, "blocklisted = ?")
+		args = append(args, *f.Blocklisted)
+	}
 
 	return strings.Join(conditions, " AND "), args
 }
@@ -331,12 +392,15 @@ type scannable interface {
 func scanProxy(s scannable) (*proxy.Proxy, error) {
 	var p proxy.Proxy
 	var protocol, anonymity string
-	var country, city, asnOrg sql.NullString
+	var country, city, asnOrg, exitIP sql.NullString
 	var latencyMs, asn sql.NullInt64
+	var supportsConnect, tlsInsecure, blocklisted, alive sql.NullBool
+	var blocklists sql.NullString
 	err := s.Scan(
 		&p.ID, &p.IP, &p.Port, &protocol, &anonymity,
-		&country, &city, &asn, &asnOrg, &latencyMs,
-		&p.LastSeen, &p.FirstSeen, &p.Alive,
+		&country, &city, &asn, &asnOrg, &exitIP, &latencyMs,
+		&supportsConnect, &tlsInsecure, &blocklisted, &blocklists,
+		&p.LastSeen, &p.FirstSeen, &alive,
 	)
 	if err != nil {
 		return nil, err
@@ -355,8 +419,26 @@ func scanProxy(s scannable) (*proxy.Proxy, error) {
 	if asnOrg.Valid {
 		p.ASNOrg = asnOrg.String
 	}
+	if exitIP.Valid {
+		p.ExitIP = exitIP.String
+	}
 	if latencyMs.Valid {
 		p.LatencyMs = int(latencyMs.Int64)
+	}
+	if supportsConnect.Valid {
+		p.SupportsConnect = supportsConnect.Bool
+	}
+	if tlsInsecure.Valid {
+		p.TLSInsecure = tlsInsecure.Bool
+	}
+	if blocklisted.Valid {
+		p.Blocklisted = blocklisted.Bool
+	}
+	if blocklists.Valid {
+		p.Blocklists = blocklists.String
+	}
+	if alive.Valid {
+		p.Alive = alive.Bool
 	}
 	return &p, nil
 }

--- a/internal/proxy/checker.go
+++ b/internal/proxy/checker.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"bufio"
 	"context"
+	"crypto/tls"
 	"encoding/binary"
 	"fmt"
 	"io"
@@ -10,28 +11,20 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strings"
 	"time"
 )
 
-// CheckerConfig holds configuration for the proxy checker.
+var ipRegex = regexp.MustCompile(`\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b`)
+
 type CheckerConfig struct {
-	// Timeout is the maximum time to wait for a proxy check.
-	Timeout time.Duration
-
-	// TestURL is the URL to request through the proxy to validate it.
-	// Should return the requesting IP in the response body.
-	TestURL string
-
-	// OriginIP is the scanner's own IP address, used for anonymity detection.
-	// If empty, anonymity detection is skipped.
+	Timeout  time.Duration
+	TestURL  string
 	OriginIP string
-
-	// Logger for structured logging.
-	Logger *slog.Logger
+	Logger   *slog.Logger
 }
 
-// DefaultConfig returns a CheckerConfig with sensible defaults.
 func DefaultConfig() CheckerConfig {
 	return CheckerConfig{
 		Timeout: 10 * time.Second,
@@ -40,22 +33,17 @@ func DefaultConfig() CheckerConfig {
 	}
 }
 
-// Checker validates proxy candidates.
 type Checker struct {
 	cfg CheckerConfig
 }
 
-// NewChecker creates a new Checker with the given config.
 func NewChecker(cfg CheckerConfig) *Checker {
 	return &Checker{cfg: cfg}
 }
 
-// Check tests a candidate across all proxy protocols and returns results
-// for each protocol that works. Returns nil results if nothing works.
 func (c *Checker) Check(ctx context.Context, candidate Candidate) []CheckResult {
 	var results []CheckResult
 
-	// Try each protocol. A single IP:port may support multiple protocols.
 	protocols := []struct {
 		proto Protocol
 		check func(ctx context.Context, candidate Candidate) *CheckResult
@@ -76,19 +64,16 @@ func (c *Checker) Check(ctx context.Context, candidate Candidate) []CheckResult 
 	return results
 }
 
-// checkHTTP tests if the candidate works as an HTTP proxy.
 func (c *Checker) checkHTTP(ctx context.Context, candidate Candidate) *CheckResult {
 	proxyURL := fmt.Sprintf("http://%s:%d", candidate.IP, candidate.Port)
 	return c.checkHTTPProxy(ctx, candidate, proxyURL, ProtocolHTTP)
 }
 
-// checkHTTPS tests if the candidate works as an HTTPS (CONNECT) proxy.
 func (c *Checker) checkHTTPS(ctx context.Context, candidate Candidate) *CheckResult {
 	proxyURL := fmt.Sprintf("http://%s:%d", candidate.IP, candidate.Port)
 	return c.checkHTTPProxy(ctx, candidate, proxyURL, ProtocolHTTPS)
 }
 
-// checkHTTPProxy performs the actual HTTP/HTTPS proxy check.
 func (c *Checker) checkHTTPProxy(ctx context.Context, candidate Candidate, proxyURL string, proto Protocol) *CheckResult {
 	result := &CheckResult{
 		Candidate: candidate,
@@ -104,7 +89,6 @@ func (c *Checker) checkHTTPProxy(ctx context.Context, candidate Candidate, proxy
 
 	testURL := c.cfg.TestURL
 	if proto == ProtocolHTTPS {
-		// For HTTPS proxy test, use an HTTPS target to force CONNECT tunnel
 		testURL = strings.Replace(testURL, "http://", "https://", 1)
 	}
 
@@ -114,7 +98,42 @@ func (c *Checker) checkHTTPProxy(ctx context.Context, candidate Candidate, proxy
 			Timeout: c.cfg.Timeout,
 		}).DialContext,
 		TLSHandshakeTimeout: c.cfg.Timeout,
-		DisableKeepAlives:   true,
+		DisableKeepAlives:    true,
+	}
+
+	if proto == ProtocolHTTPS {
+		transport.DialTLSContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+			dialer := &net.Dialer{Timeout: c.cfg.Timeout}
+			rawConn, err := dialer.DialContext(ctx, network, addr)
+			if err != nil {
+				return nil, err
+			}
+			host, _, _ := net.SplitHostPort(addr)
+			tlsConn := tls.Client(rawConn, &tls.Config{
+				InsecureSkipVerify: true,
+				ServerName:         host,
+			})
+			if err := tlsConn.Handshake(); err != nil {
+				rawConn.Close()
+				return nil, err
+			}
+			state := tlsConn.ConnectionState()
+			verified := len(state.VerifiedChains) > 0
+			if !verified {
+				result.TLSInsecure = true
+			} else {
+				for _, chain := range state.VerifiedChains {
+					for _, cert := range chain {
+						if cert.VerifyHostname(host) != nil {
+							result.TLSInsecure = true
+						}
+					}
+				}
+			}
+			return tlsConn, nil
+		}
+	} else {
+		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 	}
 
 	client := &http.Client{
@@ -142,7 +161,6 @@ func (c *Checker) checkHTTPProxy(ctx context.Context, candidate Candidate, proxy
 	}
 	defer resp.Body.Close()
 
-	// Read body (limited to 4KB — we only need the IP)
 	body, err := io.ReadAll(io.LimitReader(resp.Body, 4096))
 	if err != nil {
 		result.Error = fmt.Errorf("reading response: %w", err)
@@ -156,12 +174,53 @@ func (c *Checker) checkHTTPProxy(ctx context.Context, candidate Candidate, proxy
 
 	result.Alive = true
 	result.LatencyMs = int(latency.Milliseconds())
+	result.ExitIP = extractIP(string(body))
 	result.Anonymity = c.detectAnonymity(resp.Header, string(body))
+
+	if proto == ProtocolHTTP {
+		result.SupportsConnect = c.checkConnectMethod(ctx, candidate)
+	}
 
 	return result
 }
 
-// checkSOCKS5 tests if the candidate works as a SOCKS5 proxy.
+func (c *Checker) checkConnectMethod(ctx context.Context, candidate Candidate) bool {
+	proxyAddr := fmt.Sprintf("%s:%d", candidate.IP, candidate.Port)
+	testHost := extractHostFromURL(c.cfg.TestURL)
+	_, port, err := net.SplitHostPort(testHost)
+	if err != nil {
+		port = "80"
+	}
+	host := strings.TrimSuffix(testHost, ":"+port)
+
+	connectReq := fmt.Sprintf("CONNECT %s:%s HTTP/1.1\r\nHost: %s:%s\r\n\r\n", host, port, host, port)
+
+	dialer := &net.Dialer{Timeout: c.cfg.Timeout}
+	conn, err := dialer.DialContext(ctx, "tcp", proxyAddr)
+	if err != nil {
+		return false
+	}
+	defer conn.Close()
+
+	deadline, ok := ctx.Deadline()
+	if ok {
+		conn.SetDeadline(deadline)
+	}
+
+	if _, err := conn.Write([]byte(connectReq)); err != nil {
+		return false
+	}
+
+	conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	reader := bufio.NewReader(conn)
+	line, err := reader.ReadString('\n')
+	if err != nil {
+		return false
+	}
+
+	return strings.Contains(line, "200")
+}
+
 func (c *Checker) checkSOCKS5(ctx context.Context, candidate Candidate) *CheckResult {
 	result := &CheckResult{
 		Candidate: candidate,
@@ -181,7 +240,6 @@ func (c *Checker) checkSOCKS5(ctx context.Context, candidate Candidate) *CheckRe
 
 	start := time.Now()
 
-	// Connect to the SOCKS5 proxy
 	dialer := &net.Dialer{Timeout: c.cfg.Timeout}
 	conn, err := dialer.DialContext(ctx, "tcp", proxyAddr)
 	if err != nil {
@@ -195,14 +253,11 @@ func (c *Checker) checkSOCKS5(ctx context.Context, candidate Candidate) *CheckRe
 		conn.SetDeadline(deadline)
 	}
 
-	// SOCKS5 handshake
-	// Send greeting: version 5, 1 auth method (no auth)
 	if _, err := conn.Write([]byte{0x05, 0x01, 0x00}); err != nil {
 		result.Error = fmt.Errorf("socks5 greeting: %w", err)
 		return result
 	}
 
-	// Read server choice
 	greeting := make([]byte, 2)
 	if _, err := io.ReadFull(conn, greeting); err != nil {
 		result.Error = fmt.Errorf("socks5 greeting response: %w", err)
@@ -213,8 +268,6 @@ func (c *Checker) checkSOCKS5(ctx context.Context, candidate Candidate) *CheckRe
 		return result
 	}
 
-	// Send connect request
-	// Version(1) + CMD_CONNECT(1) + RSV(1) + ATYP_DOMAIN(1) + domain_len(1) + domain + port(2)
 	host, port := splitHostPort(targetHost, 80)
 	connectReq := []byte{0x05, 0x01, 0x00, 0x03, byte(len(host))}
 	connectReq = append(connectReq, []byte(host)...)
@@ -227,7 +280,6 @@ func (c *Checker) checkSOCKS5(ctx context.Context, candidate Candidate) *CheckRe
 		return result
 	}
 
-	// Read connect response (at least 4 bytes for header)
 	connectResp := make([]byte, 4)
 	if _, err := io.ReadFull(conn, connectResp); err != nil {
 		result.Error = fmt.Errorf("socks5 connect response: %w", err)
@@ -238,29 +290,26 @@ func (c *Checker) checkSOCKS5(ctx context.Context, candidate Candidate) *CheckRe
 		return result
 	}
 
-	// Read the rest of the response based on address type
 	switch connectResp[3] {
-	case 0x01: // IPv4
-		discard := make([]byte, 4+2) // 4 bytes IP + 2 bytes port
+	case 0x01:
+		discard := make([]byte, 4+2)
 		io.ReadFull(conn, discard)
-	case 0x03: // Domain
+	case 0x03:
 		lenBuf := make([]byte, 1)
 		io.ReadFull(conn, lenBuf)
 		discard := make([]byte, int(lenBuf[0])+2)
 		io.ReadFull(conn, discard)
-	case 0x04: // IPv6
+	case 0x04:
 		discard := make([]byte, 16+2)
 		io.ReadFull(conn, discard)
 	}
 
-	// Now we have a tunnel — send HTTP request through it
 	httpReq := fmt.Sprintf("GET / HTTP/1.1\r\nHost: %s\r\nUser-Agent: Mozilla/5.0 (compatible; proxy-check/1.0)\r\nConnection: close\r\n\r\n", host)
 	if _, err := conn.Write([]byte(httpReq)); err != nil {
 		result.Error = fmt.Errorf("socks5 http request: %w", err)
 		return result
 	}
 
-	// Read HTTP response
 	reader := bufio.NewReader(conn)
 	resp, err := http.ReadResponse(reader, nil)
 	if err != nil {
@@ -281,11 +330,11 @@ func (c *Checker) checkSOCKS5(ctx context.Context, candidate Candidate) *CheckRe
 	result.Alive = true
 	result.LatencyMs = int(latency.Milliseconds())
 	result.Anonymity = c.detectAnonymity(resp.Header, string(body))
+	result.ExitIP = extractIP(string(body))
 
 	return result
 }
 
-// checkSOCKS4 tests if the candidate works as a SOCKS4 proxy.
 func (c *Checker) checkSOCKS4(ctx context.Context, candidate Candidate) *CheckResult {
 	result := &CheckResult{
 		Candidate: candidate,
@@ -318,7 +367,6 @@ func (c *Checker) checkSOCKS4(ctx context.Context, candidate Candidate) *CheckRe
 		conn.SetDeadline(deadline)
 	}
 
-	// Resolve target host to IP (SOCKS4 requires IP, not domain)
 	host, port := splitHostPort(targetHost, 80)
 	ips, err := net.LookupHost(host)
 	if err != nil || len(ips) == 0 {
@@ -331,33 +379,28 @@ func (c *Checker) checkSOCKS4(ctx context.Context, candidate Candidate) *CheckRe
 		return result
 	}
 
-	// SOCKS4 connect request:
-	// VN(1) + CD(1) + DSTPORT(2) + DSTIP(4) + USERID + NULL(1)
 	connectReq := []byte{0x04, 0x01}
 	portBytes := make([]byte, 2)
 	binary.BigEndian.PutUint16(portBytes, uint16(port))
 	connectReq = append(connectReq, portBytes...)
 	connectReq = append(connectReq, targetIP...)
-	connectReq = append(connectReq, 0x00) // null-terminated user ID
+	connectReq = append(connectReq, 0x00)
 
 	if _, err := conn.Write(connectReq); err != nil {
 		result.Error = fmt.Errorf("socks4 connect: %w", err)
 		return result
 	}
 
-	// Read response (8 bytes)
 	resp4 := make([]byte, 8)
 	if _, err := io.ReadFull(conn, resp4); err != nil {
 		result.Error = fmt.Errorf("socks4 response: %w", err)
 		return result
 	}
-	// resp4[1] should be 0x5A for success
 	if resp4[1] != 0x5A {
 		result.Error = fmt.Errorf("socks4: connect failed with code 0x%02X", resp4[1])
 		return result
 	}
 
-	// Send HTTP request through tunnel
 	httpReq := fmt.Sprintf("GET / HTTP/1.1\r\nHost: %s\r\nUser-Agent: Mozilla/5.0 (compatible; proxy-check/1.0)\r\nConnection: close\r\n\r\n", host)
 	if _, err := conn.Write([]byte(httpReq)); err != nil {
 		result.Error = fmt.Errorf("socks4 http request: %w", err)
@@ -384,21 +427,18 @@ func (c *Checker) checkSOCKS4(ctx context.Context, candidate Candidate) *CheckRe
 	result.Alive = true
 	result.LatencyMs = int(latency.Milliseconds())
 	result.Anonymity = c.detectAnonymity(resp.Header, string(body))
+	result.ExitIP = extractIP(string(body))
 
 	return result
 }
 
-// detectAnonymity determines the anonymity level based on headers and response body.
 func (c *Checker) detectAnonymity(headers http.Header, body string) Anonymity {
 	if c.cfg.OriginIP == "" {
-		// Can't detect without knowing our own IP
 		return AnonymityAnonymous
 	}
 
-	// Check if our origin IP appears in the response body
 	originInBody := strings.Contains(body, c.cfg.OriginIP)
 
-	// Check proxy-revealing headers
 	proxyHeaders := []string{
 		"X-Forwarded-For",
 		"X-Real-IP",
@@ -428,7 +468,11 @@ func (c *Checker) detectAnonymity(headers http.Header, body string) Anonymity {
 	return AnonymityElite
 }
 
-// extractHost extracts the host:port from a URL string.
+func extractIP(body string) string {
+	match := ipRegex.FindString(body)
+	return match
+}
+
 func extractHost(rawURL string) string {
 	u, err := url.Parse(rawURL)
 	if err != nil {
@@ -446,7 +490,14 @@ func extractHost(rawURL string) string {
 	return net.JoinHostPort(host, port)
 }
 
-// splitHostPort splits a host:port string, returning defaults for missing port.
+func extractHostFromURL(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return ""
+	}
+	return u.Host
+}
+
 func splitHostPort(hostport string, defaultPort int) (string, int) {
 	host, portStr, err := net.SplitHostPort(hostport)
 	if err != nil {

--- a/internal/proxy/types.go
+++ b/internal/proxy/types.go
@@ -23,19 +23,24 @@ const (
 
 // Proxy represents a validated proxy server.
 type Proxy struct {
-	ID        int64     `json:"id"`
-	IP        string    `json:"ip"`
-	Port      int       `json:"port"`
-	Protocol  Protocol  `json:"protocol"`
-	Anonymity Anonymity `json:"anonymity,omitempty"`
-	Country   string    `json:"country,omitempty"`
-	City      string    `json:"city,omitempty"`
-	ASN       int       `json:"asn,omitempty"`
-	ASNOrg    string    `json:"asn_org,omitempty"`
-	LatencyMs int       `json:"latency_ms,omitempty"`
-	LastSeen  time.Time `json:"last_seen"`
-	FirstSeen time.Time `json:"first_seen"`
-	Alive     bool      `json:"alive"`
+	ID              int64     `json:"id"`
+	IP              string    `json:"ip"`
+	Port            int       `json:"port"`
+	Protocol        Protocol  `json:"protocol"`
+	Anonymity       Anonymity `json:"anonymity,omitempty"`
+	Country         string    `json:"country,omitempty"`
+	City            string    `json:"city,omitempty"`
+	ASN             int       `json:"asn,omitempty"`
+	ASNOrg          string    `json:"asn_org,omitempty"`
+	ExitIP          string    `json:"exit_ip,omitempty"`
+	LatencyMs       int       `json:"latency_ms,omitempty"`
+	SupportsConnect bool      `json:"supports_connect"`
+	TLSInsecure     bool      `json:"tls_insecure"`
+	Blocklisted     bool      `json:"blocklisted"`
+	Blocklists      string    `json:"blocklists,omitempty"`
+	LastSeen        time.Time `json:"last_seen"`
+	FirstSeen       time.Time `json:"first_seen"`
+	Alive           bool      `json:"alive"`
 }
 
 // Candidate represents a raw scan result from masscan — an IP:port pair
@@ -47,14 +52,17 @@ type Candidate struct {
 
 // CheckResult is the outcome of validating a single candidate.
 type CheckResult struct {
-	Candidate Candidate
-	Protocol  Protocol
-	Anonymity Anonymity
-	Country   string
-	City      string
-	LatencyMs int
-	Alive     bool
-	Error     error
+	Candidate       Candidate
+	Protocol        Protocol
+	Anonymity       Anonymity
+	ExitIP          string
+	Country         string
+	City            string
+	LatencyMs       int
+	SupportsConnect bool
+	TLSInsecure     bool
+	Alive           bool
+	Error           error
 }
 
 // ScanRun tracks metadata about a scan/validation run.
@@ -73,6 +81,7 @@ type ProxyFilter struct {
 	Anonymity  Anonymity `json:"anonymity,omitempty"`
 	Country    string    `json:"country,omitempty"`
 	MaxLatency int       `json:"max_latency,omitempty"`
+	Blocklisted *bool    `json:"blocklisted,omitempty"`
 	AliveOnly  bool      `json:"alive_only"`
 	Limit      int       `json:"limit,omitempty"`
 	Offset     int       `json:"offset,omitempty"`


### PR DESCRIPTION
## Summary

- **DNSBL blocklist checking** — Validates each proxy candidate against Spamhaus ZEN, UCEPROTECT L1, SORBS, and DroneBL. Proxies on any list are flagged with `blocklisted=true` and `blocklists` (e.g. `"zen,dnsbl"`). Disabled via `SKIP_BLOCKLIST=true` env var.
- **Exit IP capture** — Extracts the IP address the target server sees from the validation response body, stored as `exit_ip`. Useful for detecting multihop proxy chains.
- **HTTP CONNECT detection** — After validating an HTTP proxy, sends a CONNECT request to test tunneling support. Stored as `supports_connect` (bool).
- **TLS certificate validation** — HTTPS proxy check validates the cert chain and hostname. Proxies with invalid/expired certs are flagged as `tls_insecure=true`.

## Changes

- New `internal/blocklist/` package with concurrent DNSBL lookups and tests
- `internal/proxy/types.go` — Added `exit_ip`, `supports_connect`, `tls_insecure`, `blocklisted`, `blocklists` fields to `Proxy` and `CheckResult`; added `Blocklisted *bool` filter to `ProxyFilter`
- `internal/proxy/checker.go` — Exit IP extraction via regex, CONNECT method probe, TLS validation with custom `DialTLSContext`, uses `InsecureSkipVerify` on transport for HTTP
- `internal/database/sqlite.go` — Schema migration for 5 new columns (safe for existing DBs), added `blocklisted` index, updated all queries and `scanProxy`
- `cmd/validator/main.go` — Wired in blocklist checker, passes new fields through to `UpsertProxy`, added `SKIP_BLOCKLIST` env var
- `cmd/api/main.go` — Added `?blocklisted=true/false` query filter
- `docker-compose.yml` — Added `SKIP_BLOCKLIST` env var comment
- `AGENTS.md` — Updated docs for new env var, fields, and code structure

Closes #1